### PR TITLE
added install instructions for creating new user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 Newway is a file manager both for servers and for linux distros. Currently, it can perform the functions mentioned in the list above. For added security, this project implements the [jls-login system](https://github.com/naveen17797/jsonLogSys).
 
+## Installation
+Newway uses the prescence of the `jls-login.json` file to detect if a user has been created/registered. To create a user, delete the existing `jls-login.json` file from
+the home directory and revisit the url again e.g `localhost/newway` if you have placed it in xampp's htdocs folder.
+
 ### Contributors
 @[Maikuolan](https://github.com/Maikuolan)
 @[mike-bailey](https://github.com/mike-bailey)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 Newway is a file manager both for servers and for linux distros. Currently, it can perform the functions mentioned in the list above. For added security, this project implements the [jls-login system](https://github.com/naveen17797/jsonLogSys).
 
 ## Installation
-Newway uses the prescence of the `jls-login.json` file to detect if a user has been created/registered. To create a user, delete the existing `jls-login.json` file from
-the home directory and revisit the url again e.g `localhost/newway` if you have placed it in xampp's htdocs folder.
+Newway uses the prescence of the `jls-login.json` file to detect if a user has been created/registered.If you forget the password for newway the only way to reset is to delete the jls-login.json file, after deletion it will treat the user as a new user and allow registration
 
 ### Contributors
 @[Maikuolan](https://github.com/Maikuolan)


### PR DESCRIPTION
If the repo is cloned and visited from a url, it simply shows a login screen and a new user will have no idea what to login with, so I added the instructions for adding a new user.